### PR TITLE
Change to std::shared_ptr, remove hard coded object path

### DIFF
--- a/mujoco_ros_control/CMakeLists.txt
+++ b/mujoco_ros_control/CMakeLists.txt
@@ -41,7 +41,7 @@ catkin_package(
 include_directories( include
  ${Boost_INCLUDE_DIR}
  ${catkin_INCLUDE_DIRS}
- /home/user/mjpro150/include
+ /home/$ENV{USER}/mjpro150/include
 )
 
 roslint_cpp()
@@ -54,4 +54,15 @@ target_link_libraries(visualization_utils ${catkin_LIBRARIES})
 
 ## Declare a C++ library
 add_executable(mujoco_ros_control src/mujoco_ros_control.cpp)
-target_link_libraries(mujoco_ros_control ${catkin_LIBRARIES} glfw /home/user/mjpro150/bin/libmujoco150.so robot_hw_sim visualization_utils GLEW glut X11 GL GLU)
+
+target_link_libraries(mujoco_ros_control
+    ${catkin_LIBRARIES}
+    /home/$ENV{USER}/mjpro150/bin/libglfw.so.3
+    /home/$ENV{USER}/mjpro150/bin/libmujoco150.so
+    robot_hw_sim
+    visualization_utils
+    GLEW
+    glut
+    X11
+    GL
+    GLU)

--- a/mujoco_ros_control/src/mujoco_ros_control.cpp
+++ b/mujoco_ros_control/src/mujoco_ros_control.cpp
@@ -27,6 +27,7 @@
 #include <vector>
 #include <map>
 #include <algorithm>
+#include <memory>
 
 namespace mujoco_ros_control
 {
@@ -140,9 +141,9 @@ bool MujocoRosControl::init(ros::NodeHandle &nodehandle)
     const urdf::Model *const urdf_model_ptr = urdf_model.initString(urdf_string) ? &urdf_model : NULL;
 
     // get robot links from urdf
-    std::map<std::string, boost::shared_ptr<urdf::Link> > robot_links;
+    std::map<std::string, std::shared_ptr<urdf::Link> > robot_links;
     robot_links = urdf_model_ptr->links_;
-    std::map<std::string, boost::shared_ptr<urdf::Link> >::iterator it;
+    std::map<std::string, std::shared_ptr<urdf::Link> >::iterator it;
     for (it = robot_links.begin(); it != robot_links.end(); ++it)
     {
       robot_link_names_.push_back(it->first);


### PR DESCRIPTION
## Proposed changes

1. Changes the type of robot urdf link map to keep `std:shared_ptr` instead of `boost::shared_ptr`. I was not able to compile without this change as the `urdf_model->links_` attribute keeps `std::shared_ptr` values.
2. Modifies `CMakeLists.txt` to use the `USER` envvar for finding the mujoco library object path, rather than hardcoding the string `user`. Also changes linking to `glfw` to use the pre-compiled object shipped with mujoco.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [ ] Manually tested that added code works as intended (if any functional/runnable code is added).
- [ ] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [ ] Tested on real hardware (if the changed or added code is used with the real hardware).
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
